### PR TITLE
📝 docs(README.md): add reasons for using this tool and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ gh extension to execute [dep-doctor](https://github.com/kyoshidajp/dep-doctor) i
 
 2. I want to detect **only direct dependencies**. dep-doctor's feature is that it detects the maintenance state of dependencies of dependencies, but I noticed that the detected ones are not controllable for me.
 
+3. I want to notify Slack of the output results of dep-doctor. For this purpose, output in a format that can be handled programmatically is preferred. ([dep-doctor is output in text.](https://github.com/kyoshidajp/dep-doctor/blob/main/cmd/report.go)) In this tool, we implemented it in csv.
+
 ## Requirement
 
 - [dep-doctor](https://github.com/kyoshidajp/dep-doctor) v1.2.1 or later


### PR DESCRIPTION
This commit adds additional information to the README.md file. It explains the reasons for using this tool, including the desire to detect only direct dependencies and the need to notify Slack with programmatically handleable output. It also adds a requirement for using dep-doctor version 1.2.1 or later.