### PR TITLE
Release for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.0.3](https://github.com/chaspy/gh-monorepo-dep-doctor/compare/v0.0.2...v0.0.3) - 2024-04-03
+- 🔧 fix(main.go): add check for GITHUB_TOKEN environment variable by @chaspy in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/17
+- Add example to notify to Slack by @chaspy in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/19
+- Fix typo by @chaspy in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/21
+
 ## [v0.0.2](https://github.com/chaspy/gh-monorepo-dep-doctor/compare/v0.0.1...v0.0.2) - 2024-03-24
 - Support a comment for ignore file by @chaspy in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/6
 - Add test by @chaspy in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v0.0.3](https://github.com/chaspy/gh-monorepo-dep-doctor/compare/v0.0.2...v0.0.3) - 2024-04-03
+## [v0.1.0](https://github.com/chaspy/gh-monorepo-dep-doctor/compare/v0.0.2...v0.1.0) - 2024-04-03
 - 🔧 fix(main.go): add check for GITHUB_TOKEN environment variable by @chaspy in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/17
 - Add example to notify to Slack by @chaspy in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/19
 - Fix typo by @chaspy in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/21


### PR DESCRIPTION
This pull request is for the next release as v0.0.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* 🔧 fix(main.go): add check for GITHUB_TOKEN environment variable by @chaspy in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/17
* Add example to notify to Slack by @chaspy in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/19
* Fix typo by @chaspy in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/21


**Full Changelog**: https://github.com/chaspy/gh-monorepo-dep-doctor/compare/v0.0.2...v0.0.3