### PR TITLE
Release for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v1.0.0](https://github.com/chaspy/gh-monorepo-dep-doctor/compare/v0.1.0...v1.0.0) - 2024-12-15
+- Exclude proprietary Gems in Gemfile.lock by @chaspy in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/23
+- feat: Fix ignore rule formatting by @chaspy in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/27
+- chore(deps): update golangci/golangci-lint-action action to v6 by @renovate in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/26
+- chore(deps): update module github.com/golangci/golangci-lint to v1.62.2 by @renovate in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/3
+- chore(deps): update dependency golang-version to v1.23.4 by @renovate in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/1
+
 ## [v0.1.0](https://github.com/chaspy/gh-monorepo-dep-doctor/compare/v0.0.2...v0.1.0) - 2024-04-03
 - 🔧 fix(main.go): add check for GITHUB_TOKEN environment variable by @chaspy in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/17
 - Add example to notify to Slack by @chaspy in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/19


### PR DESCRIPTION
This pull request is for the next release as v1.0.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.0.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Exclude proprietary Gems in Gemfile.lock by @chaspy in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/23
* feat: Fix ignore rule formatting by @chaspy in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/27
* chore(deps): update golangci/golangci-lint-action action to v6 by @renovate in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/26
* chore(deps): update module github.com/golangci/golangci-lint to v1.62.2 by @renovate in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/3
* chore(deps): update dependency golang-version to v1.23.4 by @renovate in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/1

## New Contributors
* @renovate made their first contribution in https://github.com/chaspy/gh-monorepo-dep-doctor/pull/26

**Full Changelog**: https://github.com/chaspy/gh-monorepo-dep-doctor/compare/v0.1.0...v1.0.0